### PR TITLE
Adonis2 fix

### DIFF
--- a/R/smart_mva.R
+++ b/R/smart_mva.R
@@ -694,8 +694,8 @@ smart_mva <- function(snp_data, packed_data = FALSE, sample_group,
       message(paste0("Computing variance partioning by PERMANOVA: global test..."))
 
       # Compute PERMANOVA (global test)
-      pmanova <- vegan::adonis(formula = snp_eucli ~ group, permutations = permutation_n) # run test
-      globalTable.anova <- pmanova$aov.tab[c(1:6)] # extract ANOVA table
+      pmanova <- vegan::adonis2(formula = snp_eucli ~ group, permutations = permutation_n) # run test
+      globalTable.anova <- pmanova[c(1:5)] # extract ANOVA table
 
       message("Completed PERMANOVA: global test")
       message(paste0("Time elapsed: ", get.time(startT)))
@@ -761,10 +761,10 @@ smart_mva <- function(snp_data, packed_data = FALSE, sample_group,
               test.mat <- snp_eucli[GN, GN]
             }
             if(permanova == TRUE){
-              model.temp1 <- vegan::adonis(test.mat ~ group[GN], permutations = permutation_n)
-              F.Model.anova <- c(F.Model.anova, model.temp1$aov.tab$F.Model[1])
-              pv.anova <- c(pv.anova, model.temp1$aov.tab[[6]][1])
-              R2 <- c(R2, model.temp1$aov.tab$R2[1])
+              model.temp1 <- vegan::adonis2(test.mat ~ group[GN], permutations = permutation_n)
+              F.Model.anova <- c(F.Model.anova, model.temp1$F.Model[1])
+              pv.anova <- c(pv.anova, model.temp1[[5]][1])
+              R2 <- c(R2, model.temp1$R2[1])
             }
             if(permdisp == TRUE){
               dispCent_pair <- vegan::betadisper(stats::as.dist(test.mat), group[GN], type = dispersion_type, bias.adjust = samplesize_bias)

--- a/R/smart_mva.R
+++ b/R/smart_mva.R
@@ -762,7 +762,7 @@ smart_mva <- function(snp_data, packed_data = FALSE, sample_group,
             }
             if(permanova == TRUE){
               model.temp1 <- vegan::adonis2(test.mat ~ group[GN], permutations = permutation_n)
-              F.Model.anova <- c(F.Model.anova, model.temp1$F.Model[1])
+              F.Model.anova <- c(F.Model.anova, model.temp1$F[1])
               pv.anova <- c(pv.anova, model.temp1[[5]][1])
               R2 <- c(R2, model.temp1$R2[1])
             }

--- a/R/smart_mva.R
+++ b/R/smart_mva.R
@@ -694,7 +694,7 @@ smart_mva <- function(snp_data, packed_data = FALSE, sample_group,
       message(paste0("Computing variance partioning by PERMANOVA: global test..."))
 
       # Compute PERMANOVA (global test)
-      pmanova <- vegan::adonis2(formula = snp_eucli ~ group, permutations = permutation_n) # run test
+      pmanova <- vegan::adonis2(formula = snp_eucli ~ group, permutations = permutation_n, by = "terms") # run test
       globalTable.anova <- pmanova[c(1:5)] # extract ANOVA table
 
       message("Completed PERMANOVA: global test")
@@ -761,7 +761,7 @@ smart_mva <- function(snp_data, packed_data = FALSE, sample_group,
               test.mat <- snp_eucli[GN, GN]
             }
             if(permanova == TRUE){
-              model.temp1 <- vegan::adonis2(test.mat ~ group[GN], permutations = permutation_n)
+              model.temp1 <- vegan::adonis2(test.mat ~ group[GN], permutations = permutation_n, by = "terms")
               F.Model.anova <- c(F.Model.anova, model.temp1$F[1])
               pv.anova <- c(pv.anova, model.temp1[[5]][1])
               R2 <- c(R2, model.temp1$R2[1])

--- a/R/smart_permanova.R
+++ b/R/smart_permanova.R
@@ -125,7 +125,7 @@
 #' #compute Euclidean inter-sample distances in PCA space (triangular matrix)
 #' snp_eucli <- vegan::vegdist(pcaR1$pca.sample_coordinates[,c("PC1","PC2")], method = "euclidean")
 #' #run PERMANOVA
-#' permanova <- vegan::adonis2(formula = snp_eucli ~ my_groups, permutations = 9999)
+#' permanova <- vegan::adonis2(formula = snp_eucli ~ my_groups, permutations = 9999, by = "terms")
 #' #calculate meanSqs (groups versus residuals)
 #' meanSqs <- as.matrix(t(with(permanova, SumOfSqs/Df)[1:2]))
 #' colnames(meanSqs) <- c("Groups", "Residuals")
@@ -504,9 +504,9 @@ smart_permanova <- function(snp_data, packed_data = FALSE,
         message(paste0("Computing pairs ", paste(comb.fact[, i], collapse = " & "), "..."))
         GN <- group %in% comb.fact[, i]
         if(program_distance == "vegan"){
-          model.temp <- vegan::adonis2(as.matrix(snp_eucli, ncol = sampN)[GN, GN] ~ group[GN], permutations = permutation_n)
+          model.temp <- vegan::adonis2(as.matrix(snp_eucli, ncol = sampN)[GN, GN] ~ group[GN], permutations = permutation_n, by = "terms")
         } else {
-          model.temp <- vegan::adonis2(snp_eucli[GN, GN] ~ group[GN], permutations = permutation_n)
+          model.temp <- vegan::adonis2(snp_eucli[GN, GN] ~ group[GN], permutations = permutation_n, by = "terms")
         }
         F.Model <- c(F.Model, model.temp$F[1])
         R2 <- c(R2, model.temp$R2[1])

--- a/R/smart_permdisp.R
+++ b/R/smart_permdisp.R
@@ -147,7 +147,7 @@
 #' Patterson, N., A. L. Price and D. Reich (2006) Population structure and eigenanalysis. PLoS Genetics, 2, e190.\cr
 #' Warton, D. I., S. T. Wright and Y. Wang (2012) Distance-based multivariate analyses confound location and dispersion effects. Methods in Ecology and Evolution, 3, 89-101.
 #'
-#' @seealso \code{\link[vegan]{adonis}} (package \bold{vegan}),
+#' @seealso \code{\link[vegan]{adonis2}} (package \bold{vegan}),
 #' \code{\link[Rfast]{Dist}} (package \bold{Rfast}),
 #' \code{\link[data.table]{fread}} (package \bold{data.table}),
 #' \code{\link[vegan]{vegdist}} (package \bold{vegan}),

--- a/man/smart_permanova.Rd
+++ b/man/smart_permanova.Rd
@@ -93,7 +93,7 @@ Original acronym \code{NPMANOVA} (Non-Parametric MANOVA) replaced with PERMANOVA
 Univariate ANOVA captures differences in mean and variance referred to as location and dispersion in PERMANOVA's multivariate context (Anderson & Walsh 2013, Warton, Wright and Wang 2012).
 To attribute group differences to location (position of sample groups) and/or dispersion (spread of sample groups), PERMANOVA must be combined with PERMDISP as implemented through \code{smart_permdisp}.\cr
 
-Function \code{smart_permanova} uses \code{\link[vegan]{adonis}} to fit formula \code{snp_eucli ~ sample_group}, where \code{snp_eucli} is the sample-by-sample triangular matrix in Principal Coordinate Analysis (Gower 1966) space.
+Function \code{smart_permanova} uses \code{\link[vegan]{adonis2}} to fit formula \code{snp_eucli ~ sample_group}, where \code{snp_eucli} is the sample-by-sample triangular matrix in Principal Coordinate Analysis (Gower 1966) space.
 Current version restricted to one-way designs (one categorical predictor) though PERMANOVA can handle >1 crossed and/or nested factors (Anderson 2001) and continuous predictors (McArdle & Anderson 2001).
 If >2 sample groups tested, \code{pairwise = TRUE} allows pairwise testing and correction for multiple testing by \code{holm (Holm)} [default], \code{hochberg (Hochberg)}, \code{hommel (Hommel)}, \code{bonferroni (Bonferroni)}, \code{BY (Benjamini-Yekuieli)}, \code{BH (Benjamini-Hochberg)} or \code{fdr (False Discovery Rate)}.\cr
 
@@ -136,9 +136,9 @@ pcaR1 <- smart_pca(snp_data = pathToGenoFile, sample_group = my_groups)
 #compute Euclidean inter-sample distances in PCA space (triangular matrix)
 snp_eucli <- vegan::vegdist(pcaR1$pca.sample_coordinates[,c("PC1","PC2")], method = "euclidean")
 #run PERMANOVA
-permanova <- vegan::adonis(formula = snp_eucli ~ my_groups, permutations = 9999)
-#extract meanSqs (groups versus residuals)
-meanSqs <- as.matrix(t(permanova$aov.tab$MeanSqs[1:2]))
+permanova <- vegan::adonis2(formula = snp_eucli ~ my_groups, permutations = 9999, by = "terms")
+#calculate meanSqs (groups versus residuals)
+meanSqs <- as.matrix(t(with(permanova, SumOfSqs/Df)[1:2]))
 colnames(meanSqs) <- c("Groups", "Residuals")
 #two horizontal plots
 oldpar <- par(mfrow = c(2,1), oma = c(0,5,0.1,0.1), lwd = 2)
@@ -165,7 +165,7 @@ Patterson, N., A. L. Price and D. Reich (2006) Population structure and eigenana
 Warton, D. I., S. T. Wright and Y. Wang (2012) Distance-based multivariate analyses confound location and dispersion effects. Methods in Ecology and Evolution, 3, 89-101.
 }
 \seealso{
-\code{\link[vegan]{adonis}} (package \bold{vegan}),
+\code{\link[vegan]{adonis2}} (package \bold{vegan}),
 \code{\link[Rfast]{Dist}} (package \bold{Rfast}),
 \code{\link[data.table]{fread}} (package \bold{data.table}),
 \code{\link[vegan]{vegdist}} (package \bold{vegan}),

--- a/man/smart_permdisp.Rd
+++ b/man/smart_permdisp.Rd
@@ -162,7 +162,7 @@ Patterson, N., A. L. Price and D. Reich (2006) Population structure and eigenana
 Warton, D. I., S. T. Wright and Y. Wang (2012) Distance-based multivariate analyses confound location and dispersion effects. Methods in Ecology and Evolution, 3, 89-101.
 }
 \seealso{
-\code{\link[vegan]{adonis}} (package \bold{vegan}),
+\code{\link[vegan]{adonis2}} (package \bold{vegan}),
 \code{\link[Rfast]{Dist}} (package \bold{Rfast}),
 \code{\link[data.table]{fread}} (package \bold{data.table}),
 \code{\link[vegan]{vegdist}} (package \bold{vegan}),


### PR DESCRIPTION
This fixes two issues with `vegan::adonis2`:

1. `vegan::adonis` is deprecated and will be defunct in the nest **vegan** release scheduled to May 2025. This will change all calls to use `vegan::adonis2`.
2. The default of `vegan::adonis2` was changed to global tests. This fix will explicitly set the old behaviour with argument `by = "terms"`. See also issue #8.
